### PR TITLE
v1.4.1b

### DIFF
--- a/DynamicWin/Main/App.xaml.cs
+++ b/DynamicWin/Main/App.xaml.cs
@@ -16,7 +16,7 @@ namespace DynamicWin
         public static MMDevice defaultDevice;
         public static MMDevice defaultMicrophone;
 
-        public static string Version => "v1.4.1b";
+        public static string Version => "v1.4.2b";
         public static string ReleaseStream => "canary";
 
         [STAThread]

--- a/DynamicWin/Main/App.xaml.cs
+++ b/DynamicWin/Main/App.xaml.cs
@@ -16,7 +16,7 @@ namespace DynamicWin
         public static MMDevice defaultDevice;
         public static MMDevice defaultMicrophone;
 
-        public static string Version => "v1.4.2b";
+        public static string Version => "v1.4.1b";
         public static string ReleaseStream => "canary";
 
         [STAThread]

--- a/DynamicWin/Main/App.xaml.cs
+++ b/DynamicWin/Main/App.xaml.cs
@@ -17,7 +17,7 @@ namespace DynamicWin
         public static MMDevice defaultMicrophone;
 
         public static string Version => "v1.4.1b";
-        public static string ReleaseStream => "canary";
+        public static string ReleaseStream => "release";
 
         [STAThread]
         public static void Main()

--- a/DynamicWin/Main/App.xaml.cs
+++ b/DynamicWin/Main/App.xaml.cs
@@ -16,7 +16,8 @@ namespace DynamicWin
         public static MMDevice defaultDevice;
         public static MMDevice defaultMicrophone;
 
-        public static string Version => "v1.4.0b";
+        public static string Version => "v1.4.1b";
+        public static string ReleaseStream => "canary";
 
         [STAThread]
         public static void Main()

--- a/DynamicWin/Main/RendererMain.cs
+++ b/DynamicWin/Main/RendererMain.cs
@@ -72,7 +72,8 @@ namespace DynamicWin.Main
 
             // Start updater check sequence: wait 5s, show overlay, check for update, then open appropriate menu
             // Ensure this sequence starts only once per application lifetime
-            if (!startupUpdaterSequenceStarted)
+            // Only start automatic startup updater sequence if user opted in
+            if (!startupUpdaterSequenceStarted && Settings.AllowAutomaticUpdates)
             {
                 startupUpdaterSequenceStarted = true;
 

--- a/DynamicWin/Main/RendererMain.cs
+++ b/DynamicWin/Main/RendererMain.cs
@@ -82,6 +82,12 @@ namespace DynamicWin.Main
                     {
                         await Task.Delay(5000);
 
+                        if (MenuManager.Instance.ActiveMenu is SettingsMenu)
+                        {
+                            // If user is in SettingsMenu, don't interrupt them with updater
+                            return;
+                        }
+
                         // Show overlay manually
                         System.Windows.Application.Current?.Dispatcher.Invoke(() =>
                         {

--- a/DynamicWin/Main/Settings.cs
+++ b/DynamicWin/Main/Settings.cs
@@ -22,6 +22,7 @@ namespace DynamicWin.Main
         private static bool runOnStartup;
         private static int theme;
         private static int activeScreenIndex;
+        private static int releaseStream;
 
         public static IslandObject.IslandMode IslandMode { get => islandMode; set => islandMode = value; }
         public static bool AllowBlur { get => allowBlur; set => allowBlur = value; }
@@ -30,6 +31,7 @@ namespace DynamicWin.Main
         public static bool RunOnStartup { get => runOnStartup; set => runOnStartup = value; }
         public static int Theme { get => theme; set => theme = value; }
         public static int ScreenIndex { get => activeScreenIndex; set => activeScreenIndex = value; }
+        public static int ReleaseStream { get => releaseStream; set => releaseStream = value; }
 
         public static List<string> smallWidgetsLeft;
         public static List<string> smallWidgetsRight;
@@ -52,6 +54,7 @@ namespace DynamicWin.Main
 
                     Theme = (int)((Int64)SaveManager.Get("settings.theme"));
                     ScreenIndex = (int)((Int64)SaveManager.Get("settings.screenindex"));
+                    ReleaseStream = SaveManager.Contains("settings.ReleaseStream") ? (int)((Int64)SaveManager.Get("settings.ReleaseStream")) : 0;
 
                     Settings.smallWidgetsLeft = new List<string>();
                     Settings.smallWidgetsRight = new List<string>();
@@ -87,6 +90,7 @@ namespace DynamicWin.Main
                     AllowBlur = true;
                     AllowAnimation = true;
                     AntiAliasing = true;
+                    ReleaseStream = 0;
 
                     Theme = 0;
 
@@ -129,6 +133,7 @@ namespace DynamicWin.Main
             SaveManager.Add("settings.allowanimtion", AllowAnimation);
             SaveManager.Add("settings.antialiasing", AntiAliasing);
             SaveManager.Add("settings.runonstartup", RunOnStartup);
+            SaveManager.Add("settings.ReleaseStream", ReleaseStream);
 
             SaveManager.Add("settings.theme", Theme);
             SaveManager.Add("settings.screenindex", ScreenIndex);

--- a/DynamicWin/Main/Settings.cs
+++ b/DynamicWin/Main/Settings.cs
@@ -23,6 +23,7 @@ namespace DynamicWin.Main
         private static int theme;
         private static int activeScreenIndex;
         private static int releaseStream;
+        private static bool allowAutomaticUpdates = true;
 
         public static IslandObject.IslandMode IslandMode { get => islandMode; set => islandMode = value; }
         public static bool AllowBlur { get => allowBlur; set => allowBlur = value; }
@@ -32,6 +33,7 @@ namespace DynamicWin.Main
         public static int Theme { get => theme; set => theme = value; }
         public static int ScreenIndex { get => activeScreenIndex; set => activeScreenIndex = value; }
         public static int ReleaseStream { get => releaseStream; set => releaseStream = value; }
+        public static bool AllowAutomaticUpdates { get => allowAutomaticUpdates; set => allowAutomaticUpdates = value; }
 
         public static List<string> smallWidgetsLeft;
         public static List<string> smallWidgetsRight;
@@ -51,6 +53,8 @@ namespace DynamicWin.Main
                     AllowAnimation = (bool)SaveManager.Get("settings.allowanimtion");
                     AntiAliasing = (bool)SaveManager.Get("settings.antialiasing");
                     RunOnStartup = (bool)SaveManager.Get("settings.runonstartup");
+
+                    AllowAutomaticUpdates = SaveManager.Contains("settings.AllowAutomaticUpdates") ? (bool)SaveManager.Get("settings.AllowAutomaticUpdates") : true;
 
                     Theme = (int)((Int64)SaveManager.Get("settings.theme"));
                     ScreenIndex = (int)((Int64)SaveManager.Get("settings.screenindex"));
@@ -91,6 +95,9 @@ namespace DynamicWin.Main
                     AllowAnimation = true;
                     AntiAliasing = true;
                     ReleaseStream = 0;
+
+                    // default automatic updates enabled
+                    AllowAutomaticUpdates = true;
 
                     Theme = 0;
 
@@ -134,6 +141,8 @@ namespace DynamicWin.Main
             SaveManager.Add("settings.antialiasing", AntiAliasing);
             SaveManager.Add("settings.runonstartup", RunOnStartup);
             SaveManager.Add("settings.ReleaseStream", ReleaseStream);
+
+            SaveManager.Add("settings.AllowAutomaticUpdates", AllowAutomaticUpdates);
 
             SaveManager.Add("settings.theme", Theme);
             SaveManager.Add("settings.screenindex", ScreenIndex);

--- a/DynamicWin/UI/Menu/Menus/SettingsMenu.cs
+++ b/DynamicWin/UI/Menu/Menus/SettingsMenu.cs
@@ -44,6 +44,7 @@ namespace DynamicWin.UI.Menu.Menus
             Settings.AllowAnimation = allowAnimation.IsChecked;
             Settings.AntiAliasing = antiAliasing.IsChecked;
             Settings.RunOnStartup = runOnStartup.IsChecked;
+            Settings.AllowAutomaticUpdates = allowAutomaticUpdates.IsChecked;
 
             DynamicWinMain.UpdateStartup();
 
@@ -67,6 +68,7 @@ namespace DynamicWin.UI.Menu.Menus
         DWCheckbox allowAnimation;
         DWCheckbox antiAliasing;
         DWCheckbox runOnStartup;
+        DWCheckbox allowAutomaticUpdates;
 
         UIObject bottomMask;
 
@@ -125,6 +127,10 @@ namespace DynamicWin.UI.Menu.Menus
             runOnStartup.Anchor.X = 0;
             objects.Add(runOnStartup);
 
+            allowAutomaticUpdates = new DWCheckbox(island, "Allow automatic updates", new Vec2(25, 0), new Vec2(25, 25), () => { }, UIAlignment.TopLeft);
+            allowAutomaticUpdates.IsChecked = Settings.AllowAutomaticUpdates;
+            allowAutomaticUpdates.Anchor.X = 0;
+            objects.Add(allowAutomaticUpdates);
 
             {
                 var selectedMonitorTitle = new DWText(island, "Selected Monitor", new Vec2(25, 0), UIAlignment.TopLeft);
@@ -254,30 +260,72 @@ namespace DynamicWin.UI.Menu.Menus
 
             var releaseStreamTitle = new DWText(island, "Release Stream", new Vec2(25, 0), UIAlignment.TopLeft);
             releaseStreamTitle.Font = Res.SatoshiBold;
-            releaseStreamTitle.TextSize = 15;
             releaseStreamTitle.Color = Theme.TextMain;
             releaseStreamTitle.Anchor.X = 0;
             objects.Add(releaseStreamTitle);
 
-            var releaseStreamDisclaimer = new DWText(island, "Updates will be checked after you restart the application.", new Vec2(25, -15), UIAlignment.TopLeft);
-            releaseStreamDisclaimer.Font = Res.SatoshiRegular;
-            releaseStreamDisclaimer.TextSize = 12;
-            releaseStreamDisclaimer.Color = Theme.TextSecond;
-            releaseStreamDisclaimer.Anchor.X = 0;
-            objects.Add(releaseStreamDisclaimer);
+            var releaseStreamDisclaimerPt1 = new DWText(island, "Updates will be checked after you restart the application", new Vec2(25, -15), UIAlignment.TopLeft);
+            releaseStreamDisclaimerPt1.Font = Res.SatoshiRegular;
+            releaseStreamDisclaimerPt1.TextSize = 12;
+            releaseStreamDisclaimerPt1.Color = Theme.TextSecond;
+            releaseStreamDisclaimerPt1.Anchor.X = 0;
+            objects.Add(releaseStreamDisclaimerPt1);
+
+            var releaseStreamDisclaimerPt2 = new DWText(island, "or by pressing the 'Check for updates now' button.", new Vec2(25, -30), UIAlignment.TopLeft);
+            releaseStreamDisclaimerPt2.Font = Res.SatoshiRegular;
+            releaseStreamDisclaimerPt2.TextSize = 12;
+            releaseStreamDisclaimerPt2.Color = Theme.TextSecond;
+            releaseStreamDisclaimerPt2.Anchor.X = 0;
+            objects.Add(releaseStreamDisclaimerPt2);
             {
                 var releaseStreams = new string[] { "Release", "Canary" };
-                var releaseStream = new DWMultiSelectionButton(island, releaseStreams, new Vec2(25, -15), new Vec2(IslandSize().X - 50, 25), UIAlignment.TopLeft);
+                var releaseStream = new DWMultiSelectionButton(island, releaseStreams, new Vec2(25, -25), new Vec2(IslandSize().X - 50, 30), UIAlignment.TopLeft);
                 releaseStream.SelectedIndex = Settings.ReleaseStream;
                 releaseStream.Anchor.X = 0;
                 releaseStream.onClick += (index) =>
                 {
                     Settings.ReleaseStream = index;
+                    Settings.Save();
                 };
                 objects.Add(releaseStream);
             }
 
-            objects.Add(new DWText(island, $"Application version: {DynamicWinMain.Version} ({DynamicWinMain.ReleaseStream})", new Vec2(25, 0), UIAlignment.TopLeft)
+            // Trigger update logic immediately upon pressing the update button
+            var checkForUpdateBtn = new DWTextButton(island, "Check for updates now", new Vec2(25, -25), new Vec2(IslandSize().X - 360, 30), () =>
+            {
+                SaveManager.Add("settings.ReleaseStream", Settings.ReleaseStream);
+
+                // Show overlay immediately on UI thread
+                MenuManager.OpenOverlayMenu(new UpdaterOverlay(), 0f);
+
+                // Perform check in background
+                _ = Task.Run(async () =>
+                {
+                    var updater = new Updater();
+                    AppVersion? update = null;
+                    try { update = await updater.CheckForUpdate(); } catch { update = null; }
+
+                    // Back to UI thread to update menus
+                    System.Windows.Application.Current?.Dispatcher.Invoke(() =>
+                    {
+                        MenuManager.CloseOverlay();
+                        MenuManager.Instance?.UnlockMenu();
+
+                        if (update == null)
+                        {
+                            MenuManager.OpenMenu(Res.HomeMenu);
+                        }
+                        else
+                        {
+                            MenuManager.OpenMenu(new UpdaterMenu(update));
+                        }
+                    });
+                });
+            }, UIAlignment.TopLeft);
+            checkForUpdateBtn.Anchor.X = 0;
+            objects.Add(checkForUpdateBtn);
+
+            objects.Add(new DWText(island, $"Application version: {DynamicWinMain.Version} ({DynamicWinMain.ReleaseStream})", new Vec2(25, -15), UIAlignment.TopLeft)
             {
                 Color = Theme.TextMain,
                 Anchor = new Vec2(0, 0),
@@ -285,21 +333,21 @@ namespace DynamicWin.UI.Menu.Menus
                 Font = Res.SatoshiBold
             });
 
-            objects.Add(new DWText(island, "Maintained and developed by 59xa", new Vec2(25, 0), UIAlignment.TopLeft)
+            objects.Add(new DWText(island, "Maintained and developed by 59xa", new Vec2(25, -25), UIAlignment.TopLeft)
             {
                 Color = Theme.TextThird,
                 Anchor = new Vec2(0, 0.5f),
                 TextSize = 13,
             });
 
-            objects.Add(new DWText(island, "Created by Florian Butz", new Vec2(25, 0), UIAlignment.TopLeft)
+            objects.Add(new DWText(island, "Created by Florian Butz", new Vec2(25, -25), UIAlignment.TopLeft)
             {
                 Color = Theme.TextThird,
                 Anchor = new Vec2(0, 0.5f),
                 TextSize = 13
             });
 
-            objects.Add(new DWText(island, "Licenced under CC BY-SA 4.0", new Vec2(25, 0), UIAlignment.TopLeft)
+            objects.Add(new DWText(island, "Licenced under CC BY-SA 4.0", new Vec2(25, -25), UIAlignment.TopLeft)
             {
                 Color = Theme.TextThird,
                 Anchor = new Vec2(0, 0.5f),
@@ -355,7 +403,7 @@ namespace DynamicWin.UI.Menu.Menus
                 uiObject.LocalPosition.Y = yPos + ySmoothScroll;
                 yPos += uiObject.Size.Y + spacing;
 
-                if (yPos > IslandSize().Y - 45) yScrollLim += uiObject.Size.Y + spacing;
+                if (yPos > IslandSize().Y - 50) yScrollLim += uiObject.Size.Y + spacing;
             }
 
             yScrollOffset = Mathf.Lerp(yScrollOffset,

--- a/DynamicWin/UI/Menu/Menus/SettingsMenu.cs
+++ b/DynamicWin/UI/Menu/Menus/SettingsMenu.cs
@@ -318,7 +318,8 @@ namespace DynamicWin.UI.Menu.Menus
                 alpha = 0.7f,
                 roundRadius = 50,
                 shadowStrength = 10f,
-                shadowColor = new Col(0, 0, 0)
+                shadowColor = Theme.IslandBackground,
+                Color = Theme.IslandBackground
             };
 
             objects.Add(bottomMask);

--- a/DynamicWin/UI/Menu/Menus/SettingsMenu.cs
+++ b/DynamicWin/UI/Menu/Menus/SettingsMenu.cs
@@ -252,34 +252,58 @@ namespace DynamicWin.UI.Menu.Menus
                 }
             }
 
-            objects.Add(new DWText(island, "Software version: " + DynamicWinMain.Version, new Vec2(25, 0), UIAlignment.TopLeft)
+            var releaseStreamTitle = new DWText(island, "Release Stream", new Vec2(25, 0), UIAlignment.TopLeft);
+            releaseStreamTitle.Font = Res.SatoshiBold;
+            releaseStreamTitle.TextSize = 15;
+            releaseStreamTitle.Color = Theme.TextMain;
+            releaseStreamTitle.Anchor.X = 0;
+            objects.Add(releaseStreamTitle);
+
+            var releaseStreamDisclaimer = new DWText(island, "Updates will be checked after you restart the application.", new Vec2(25, -15), UIAlignment.TopLeft);
+            releaseStreamDisclaimer.Font = Res.SatoshiRegular;
+            releaseStreamDisclaimer.TextSize = 12;
+            releaseStreamDisclaimer.Color = Theme.TextSecond;
+            releaseStreamDisclaimer.Anchor.X = 0;
+            objects.Add(releaseStreamDisclaimer);
             {
-                Color = Theme.TextThird,
-                Anchor = new Vec2(0, 0.5f),
+                var releaseStreams = new string[] { "Release", "Canary" };
+                var releaseStream = new DWMultiSelectionButton(island, releaseStreams, new Vec2(25, -15), new Vec2(IslandSize().X - 50, 25), UIAlignment.TopLeft);
+                releaseStream.SelectedIndex = Settings.ReleaseStream;
+                releaseStream.Anchor.X = 0;
+                releaseStream.onClick += (index) =>
+                {
+                    Settings.ReleaseStream = index;
+                };
+                objects.Add(releaseStream);
+            }
+
+            objects.Add(new DWText(island, $"Application version: {DynamicWinMain.Version} ({DynamicWinMain.ReleaseStream})", new Vec2(25, 0), UIAlignment.TopLeft)
+            {
+                Color = Theme.TextMain,
+                Anchor = new Vec2(0, 0),
                 TextSize = 15,
                 Font = Res.SatoshiBold
-            });
-
-            objects.Add(new DWText(island, "Created by Florian Butz", new Vec2(25, 0), UIAlignment.TopLeft)
-            {
-                Color = Theme.TextThird,
-                Anchor = new Vec2(0, 0.5f),
-                TextSize = 15
             });
 
             objects.Add(new DWText(island, "Maintained and developed by 59xa", new Vec2(25, 0), UIAlignment.TopLeft)
             {
                 Color = Theme.TextThird,
                 Anchor = new Vec2(0, 0.5f),
-                TextSize = 15,
-                Font = Resources.Res.SatoshiBold
+                TextSize = 13,
+            });
+
+            objects.Add(new DWText(island, "Created by Florian Butz", new Vec2(25, 0), UIAlignment.TopLeft)
+            {
+                Color = Theme.TextThird,
+                Anchor = new Vec2(0, 0.5f),
+                TextSize = 13
             });
 
             objects.Add(new DWText(island, "Licenced under CC BY-SA 4.0", new Vec2(25, 0), UIAlignment.TopLeft)
             {
                 Color = Theme.TextThird,
                 Anchor = new Vec2(0, 0.5f),
-                TextSize = 15
+                TextSize = 13
             });
 
             var backBtn = new DWTextButton(island, "Save changes", new Vec2(0, -45), new Vec2(250, 40), () => { SaveAndBack(); }, UIAlignment.BottomCenter)

--- a/DynamicWin/UI/Menu/Menus/SettingsMenuObjects/BigWidgetAdderDisplay.cs
+++ b/DynamicWin/UI/Menu/Menus/SettingsMenuObjects/BigWidgetAdderDisplay.cs
@@ -21,7 +21,7 @@ namespace DynamicWin.UI.Menu.Menus.SettingsMenuObjects
 
             roundRadius = 45;
 
-            color = Theme.WidgetBackground.Override(a: 0.15f);
+            color = Theme.Primary.Override();
         }
 
         public override void Draw(SKCanvas canvas)

--- a/DynamicWin/UI/Menu/Menus/UpdaterMenu.cs
+++ b/DynamicWin/UI/Menu/Menus/UpdaterMenu.cs
@@ -34,6 +34,7 @@ namespace DynamicWin.UI.Menu.Menus
         // The update object received from RendererMain
         internal AppVersion update { get; }
         private string latestVersion;
+        private string releaseStream;
 
         // UI elements
         DWText subUpdaterText;
@@ -64,6 +65,7 @@ namespace DynamicWin.UI.Menu.Menus
             validUpdate = (update != null) && !string.IsNullOrWhiteSpace(update.version) && !string.IsNullOrWhiteSpace(update.downloadUri);
 
             latestVersion = DisplayVersion();
+            releaseStream = DisplayReleaseStream();
 
 #if DEBUG
             Debug.WriteLine($"[UPDATER] Constructor: validUpdate = {validUpdate}, update.version = {update?.version}");
@@ -75,6 +77,14 @@ namespace DynamicWin.UI.Menu.Menus
         {
             if (update != null && !string.IsNullOrWhiteSpace(update.version))
                 return update.version;
+            else
+                return "unknown";
+        }
+
+        private string DisplayReleaseStream()
+        {
+            if (update != null && !string.IsNullOrWhiteSpace(update.releaseStream))
+                return update.releaseStream;
             else
                 return "unknown";
         }
@@ -127,7 +137,7 @@ namespace DynamicWin.UI.Menu.Menus
 
             MainForm.Instance?.UpdateTrayButtons();
 
-            versionText.Text = $"New version: {latestVersion}";
+            versionText.Text = $"New version: {latestVersion} ({releaseStream})";
 
             // Start countdown once (only for valid update)
             if (!countdownStarted && validUpdate)

--- a/DynamicWin/UI/UIElements/DWButton.cs
+++ b/DynamicWin/UI/UIElements/DWButton.cs
@@ -37,7 +37,7 @@ namespace DynamicWin.UI.UIElements
         {
             initialScale = size;
 
-            roundRadius = 5f;
+            roundRadius = 20f;
             scaleSecondOrder = new SecondOrder(size, 4.5f, 0.45f, 0.15f);
             this.clickCallback = clickCallback;
 

--- a/DynamicWin/Utils/Updater.cs
+++ b/DynamicWin/Utils/Updater.cs
@@ -54,45 +54,93 @@ namespace DynamicWin.Utils
         {
             try
             {
-                // Always fetch release first
+#if DEBUG
+                Debug.WriteLine($"[UPDATER]: current version = {DynamicWinMain.Version}");
+                Debug.WriteLine($"[UPDATER]: selected stream = {(Settings.ReleaseStream == 1 ? "canary" : "release")}");
+#endif
+
                 var release = await FetchRemote("version.json");
 
-                if (release != null &&
-                    CompareVersionStrings(release.version, DynamicWinMain.Version) > 0)
+#if DEBUG
+                if (release != null)
+                    Debug.WriteLine($"[UPDATER]: remote release = {release.version}");
+                else
+                    Debug.WriteLine("[UPDATER]: failed to fetch release");
+#endif
+
+                // FORCE REVERT: canary -> release
+                if (Settings.ReleaseStream == 0 &&
+                    DynamicWinMain.ReleaseStream == "canary" &&
+                    release != null)
                 {
 #if DEBUG
-                    Debug.WriteLine("[UPDATER]: release update available -> prioritised");
+                    Debug.WriteLine("[UPDATER]: stream switch detected (canary -> release), forcing revert");
 #endif
                     return release;
+                }
+
+                // Normal forward update: release
+                if (release != null)
+                {
+                    int cmp = CompareVersionStrings(release.version, DynamicWinMain.Version);
+
+#if DEBUG
+                    Debug.WriteLine($"[UPDATER]: release compare -> {cmp}");
+#endif
+
+                    if (cmp > 0)
+                    {
+#if DEBUG
+                        Debug.WriteLine("[UPDATER]: release update available -> prioritised");
+#endif
+                        return release;
+                    }
                 }
 
                 // If user is NOT on canary, stop here
                 if (Settings.ReleaseStream != 1)
                 {
 #if DEBUG
-                    Debug.WriteLine("[UPDATER]: release stream is not canary, stopping");
+                    Debug.WriteLine("[UPDATER]: not on canary stream, stopping");
 #endif
                     return null;
                 }
 
-                // User opted into canary, now check it
                 var canary = await FetchRemote("version-canary.json");
 
-                if (canary != null &&
-                    CompareVersionStrings(canary.version, DynamicWinMain.Version) > 0)
-                {
 #if DEBUG
-                    Debug.WriteLine("[UPDATER]: canary update available");
+                if (canary != null)
+                    Debug.WriteLine($"[UPDATER]: remote canary = {canary.version}");
+                else
+                    Debug.WriteLine("[UPDATER]: failed to fetch canary");
 #endif
-                    return canary;
+
+                if (canary != null)
+                {
+                    int cmp = CompareVersionStrings(canary.version, DynamicWinMain.Version);
+
+#if DEBUG
+                    Debug.WriteLine($"[UPDATER]: canary compare -> {cmp}");
+#endif
+
+                    if (cmp > 0)
+                    {
+#if DEBUG
+                        Debug.WriteLine("[UPDATER]: canary update available");
+#endif
+                        return canary;
+                    }
                 }
 
+#if DEBUG
+                Debug.WriteLine("[UPDATER]: no update available");
+#endif
                 return null;
             }
             catch (Exception ex)
             {
 #if DEBUG
-                Debug.WriteLine("[UPDATER]: exception while checking for update: " + ex.Message);
+                Debug.WriteLine("[UPDATER]: exception while checking for update: " + ex);
 #endif
                 return null;
             }

--- a/DynamicWin/Utils/Updater.cs
+++ b/DynamicWin/Utils/Updater.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Net.Http;
 using System.Text.Json;
 using System;
+using DynamicWin.Main;
 
 /*
  *
@@ -13,7 +14,7 @@ using System;
  *  Author:                 59xa
  *  Github:                 https://github.com/59xa
  *  Implementation Date:    27 November 2025
- *  Last Modified:          28 November 2025
+ *  Last Modified:          19 December 2025
  *
  */
 
@@ -21,6 +22,25 @@ namespace DynamicWin.Utils
 {
     internal class Updater
     {
+        /// <summary>
+        /// Retrieves and deserializes an application version definition from a remote JSON file hosted on GitHub.
+        /// </summary>
+        /// <remarks>This performs an HTTP GET request to the specified file in the updater branch
+        /// inside the repository. The JSON is deserialised in a case-insensitive manner. Network failures
+        /// or invalid JSON will result in a <see langword="null"/> return value.</remarks>
+        /// <param name="file">The name of the JSON file to fetch from the remote repository. Cannot be null or empty.</param>
+        /// <returns>A task that represents the asynchronous operation. The task result contains an <see cref="AppVersion"/>
+        /// object if the file is successfully retrieved and deserialised; otherwise, <see langword="null"/>.</returns>
+        private async Task<AppVersion?> FetchRemote(string file)
+        {
+            using HttpClient client = new();
+            string json = await client.GetStringAsync(
+                $"https://raw.githubusercontent.com/59xa/DynamicWin-Legacy/refs/heads/updater/{file}");
+
+            var options = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };
+            return JsonSerializer.Deserialize<AppVersion>(json, options);
+        }
+
         /// <summary>
         /// Checks for a newer version of DynamicWin-Legacy by retrieving version information from a remote source.
         /// </summary>
@@ -34,106 +54,40 @@ namespace DynamicWin.Utils
         {
             try
             {
-                using HttpClient client = new();
-                string json = await client.GetStringAsync("https://raw.githubusercontent.com/59xa/DynamicWin-Legacy/refs/heads/updater/version.json");
+                // Always fetch release first
+                var release = await FetchRemote("version.json");
 
-                var options = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };
-                var remote = JsonSerializer.Deserialize<AppVersion>(json, options);
-
-                // Fallback: if properties are null due to unexpected schema/casing, try to read them manually
-                if (remote == null)
+                if (release != null &&
+                    CompareVersionStrings(release.version, DynamicWinMain.Version) > 0)
                 {
 #if DEBUG
-                    Debug.WriteLine("[UPDATER]: remote payload was null after deserialization");
+                    Debug.WriteLine("[UPDATER]: release update available -> prioritised");
+#endif
+                    return release;
+                }
+
+                // If user is NOT on canary, stop here
+                if (Settings.ReleaseStream != 1)
+                {
+#if DEBUG
+                    Debug.WriteLine("[UPDATER]: release stream is not canary, stopping");
 #endif
                     return null;
                 }
 
-                if (string.IsNullOrWhiteSpace(remote.version) || string.IsNullOrWhiteSpace(remote.downloadUri))
-                {
-                    try
-                    {
-                        using var doc = JsonDocument.Parse(json);
-                        var root = doc.RootElement;
+                // User opted into canary, now check it
+                var canary = await FetchRemote("version-canary.json");
 
-                        if (string.IsNullOrWhiteSpace(remote.version))
-                        {
-                            foreach (var prop in root.EnumerateObject())
-                            {
-                                if (string.Equals(prop.Name, "version", StringComparison.OrdinalIgnoreCase) || string.Equals(prop.Name, "ver", StringComparison.OrdinalIgnoreCase))
-                                {
-                                    if (prop.Value.ValueKind == JsonValueKind.String)
-                                        remote.version = prop.Value.GetString();
-                                    break;
-                                }
-                            }
-                        }
-
-                        if (string.IsNullOrWhiteSpace(remote.downloadUri))
-                        {
-                            foreach (var prop in root.EnumerateObject())
-                            {
-                                if (string.Equals(prop.Name, "downloadUri", StringComparison.OrdinalIgnoreCase) || string.Equals(prop.Name, "download", StringComparison.OrdinalIgnoreCase) || string.Equals(prop.Name, "url", StringComparison.OrdinalIgnoreCase))
-                                {
-                                    if (prop.Value.ValueKind == JsonValueKind.String)
-                                        remote.downloadUri = prop.Value.GetString();
-                                    break;
-                                }
-                            }
-                        }
-                    }
-                    catch
-                    {
-                        // ignore, we'll validate below
-                    }
-                }
-
-                // Validate remote payload now
-                if (string.IsNullOrWhiteSpace(remote.version))
+                if (canary != null &&
+                    CompareVersionStrings(canary.version, DynamicWinMain.Version) > 0)
                 {
 #if DEBUG
-                    Debug.WriteLine("[UPDATER]: remote.version is null or empty after fallback extraction");
+                    Debug.WriteLine("[UPDATER]: canary update available");
 #endif
-                    return null;
+                    return canary;
                 }
 
-                if (string.IsNullOrWhiteSpace(remote.downloadUri))
-                {
-#if DEBUG
-                    Debug.WriteLine("[UPDATER]: remote.downloadUri is null or empty after fallback extraction");
-#endif
-                    return null;
-                }
-
-                int cmp;
-                try
-                {
-                    // Compare remote (a) to current (b)
-                    cmp = CompareVersionStrings(remote.version, DynamicWinMain.Version);
-                }
-                catch (Exception ex)
-                {
-#if DEBUG
-                    Debug.WriteLine("[UPDATER]: version comparison failed: " + ex.Message);
-#endif
-                    // Fallback: attempt numeric parse only; if fails, give up
-                    try
-                    {
-                        Version current = ParseVersion(DynamicWinMain.Version);
-                        Version latest = ParseVersion(remote.version);
-                        cmp = latest.CompareTo(current);
-                    }
-                    catch
-                    {
-                        return null;
-                    }
-                }
-
-#if DEBUG
-                Debug.WriteLine($"[UPDATER]: Comparing remote '{remote.version}' to current '{DynamicWinMain.Version}' -> cmp={cmp}");
-#endif
-
-                return cmp > 0 ? remote : null;
+                return null;
             }
             catch (Exception ex)
             {

--- a/DynamicWin/Utils/Updater.cs
+++ b/DynamicWin/Utils/Updater.cs
@@ -224,5 +224,6 @@ namespace DynamicWin.Utils
     {
         public string version { get; set; }
         public string downloadUri { get; set; }
+        public string releaseStream { get; set; }
     }
 }


### PR DESCRIPTION
# What's new in v1.4.1b?
- Tweaked updater logic to handle updating and downgrading versions
    - Also provide release streams `release` and `canary`.
    - `release` streams provide the current stable version of the application while `canary` provides latest, yet unstable versions for early access and testing.
- Allow user to opt-in for automatic updates
    - This means that users can choose to not update versions during startup
- Visual tweaks for buttons (noticeable in the settings menu)