### PR TITLE
v1.4.1b1, hotfix

### DIFF
--- a/DynamicWin/Main/App.xaml.cs
+++ b/DynamicWin/Main/App.xaml.cs
@@ -16,7 +16,7 @@ namespace DynamicWin
         public static MMDevice defaultDevice;
         public static MMDevice defaultMicrophone;
 
-        public static string Version => "v1.4.2a";
+        public static string Version => "v1.4.2a1";
         public static string ReleaseStream => "canary";
 
         [STAThread]

--- a/DynamicWin/Main/App.xaml.cs
+++ b/DynamicWin/Main/App.xaml.cs
@@ -16,8 +16,8 @@ namespace DynamicWin
         public static MMDevice defaultDevice;
         public static MMDevice defaultMicrophone;
 
-        public static string Version => "v1.4.1b";
-        public static string ReleaseStream => "release";
+        public static string Version => "v1.4.2a";
+        public static string ReleaseStream => "canary";
 
         [STAThread]
         public static void Main()

--- a/DynamicWin/Utils/Updater.cs
+++ b/DynamicWin/Utils/Updater.cs
@@ -223,21 +223,69 @@ namespace DynamicWin.Utils
         }
 
         // New helpers to support prerelease comparison
-        private record VersionInfo(Version Numeric, string? Pre);
+        private enum PreType
+        {
+            Alpha = 0,
+            Beta = 1,
+            RC = 2,
+            Unknown = -1
+        }
+
+        private record VersionInfo(
+            Version Numeric,
+            PreType Type,
+            int PreNumber
+        );
 
         private static VersionInfo ParseVersionWithPre(string raw)
         {
             raw = (raw ?? string.Empty).Trim().ToLower();
-            if (raw.StartsWith("v")) raw = raw.Substring(1);
+            if (raw.StartsWith("v"))
+                raw = raw.Substring(1);
 
             int i = 0;
-            while (i < raw.Length && (char.IsDigit(raw[i]) || raw[i] == '.')) i++;
+            while (i < raw.Length && (char.IsDigit(raw[i]) || raw[i] == '.'))
+                i++;
 
-            string numeric = raw.Substring(0, i);
-            string pre = i < raw.Length ? raw.Substring(i) : string.Empty;
+            string numericPart = raw.Substring(0, i);
+            string prePart = i < raw.Length ? raw.Substring(i) : string.Empty;
 
-            return new VersionInfo(new Version(numeric), pre);
+            var numeric = new Version(numericPart);
+
+            if (string.IsNullOrEmpty(prePart))
+                return new VersionInfo(numeric, PreType.Unknown, 0);
+
+            PreType type;
+            int numStart;
+
+            if (prePart.StartsWith("a"))
+            {
+                type = PreType.Alpha;
+                numStart = 1;
+            }
+            else if (prePart.StartsWith("b"))
+            {
+                type = PreType.Beta;
+                numStart = 1;
+            }
+            else if (prePart.StartsWith("rc"))
+            {
+                type = PreType.RC;
+                numStart = 2;
+            }
+            else
+            {
+                type = PreType.Unknown;
+                numStart = prePart.Length;
+            }
+
+            int number = 0;
+            if (numStart < prePart.Length)
+                int.TryParse(prePart.Substring(numStart), out number);
+
+            return new VersionInfo(numeric, type, number);
         }
+
 
         /// <summary>
         /// Compare version strings that may include prerelease suffixes.
@@ -253,18 +301,23 @@ namespace DynamicWin.Utils
             var vb = ParseVersionWithPre(b);
 
             int numCmp = va.Numeric.CompareTo(vb.Numeric);
-            if (numCmp != 0) return numCmp;
+            if (numCmp != 0)
+                return numCmp;
 
-            bool aIsRelease = string.IsNullOrEmpty(va.Pre);
-            bool bIsRelease = string.IsNullOrEmpty(vb.Pre);
+            bool aIsRelease = va.Type == PreType.Unknown;
+            bool bIsRelease = vb.Type == PreType.Unknown;
 
             if (aIsRelease && bIsRelease) return 0;
-            if (aIsRelease) return 1; // release is newer than prerelease
+            if (aIsRelease) return 1;   // release beats prerelease
             if (bIsRelease) return -1;
 
-            // both prerelease -> compare lexicographically
-            return string.Compare(va.Pre, vb.Pre, StringComparison.OrdinalIgnoreCase);
+            int typeCmp = va.Type.CompareTo(vb.Type);
+            if (typeCmp != 0)
+                return typeCmp;
+
+            return va.PreNumber.CompareTo(vb.PreNumber);
         }
+
 
     }
 

--- a/DynamicWin/Utils/Updater.cs
+++ b/DynamicWin/Utils/Updater.cs
@@ -237,6 +237,17 @@ namespace DynamicWin.Utils
             int PreNumber
         );
 
+        /// <summary>
+        /// Parses a version string that may include a pre-release identifier into a VersionInfo object.
+        /// </summary>
+        /// <remarks>The method supports version strings with or without a leading 'v' (e.g., 'v1.2.3').
+        /// Recognised pre-release identifiers are 'a' (alpha), 'b' (beta), and 'rc' (release candidate), optionally
+        /// followed by a number (e.g., '1.2.3rc2'). If the pre-release part is missing or unrecognised, the pre-release
+        /// type is set to Unknown and the number is set to 0.</remarks>
+        /// <param name="raw">The raw version string to parse. May include an optional leading 'v' and a pre-release suffix such as 'a',
+        /// 'b', or 'rc' followed by a number.</param>
+        /// <returns>A VersionInfo object representing the parsed version and pre-release information. If the pre-release part is
+        /// not recognised, the pre-release type is set to Unknown.</returns>
         private static VersionInfo ParseVersionWithPre(string raw)
         {
             raw = (raw ?? string.Empty).Trim().ToLower();


### PR DESCRIPTION
- Fixes `Updater.cs` by requiring elevated access when updating. Only require elevated access if user installed into `C:\Program Files` or `C:\Program Files (x86)`.
- Support pre-type versioning for future-proofing.