### PR TITLE
v1.4.2b hotfix

### DIFF
--- a/DynamicWin/Main/App.xaml.cs
+++ b/DynamicWin/Main/App.xaml.cs
@@ -16,7 +16,7 @@ namespace DynamicWin
         public static MMDevice defaultDevice;
         public static MMDevice defaultMicrophone;
 
-        public static string Version => "v1.4.1b1";
+        public static string Version => "v1.4.2b";
         public static string ReleaseStream => "release";
 
         [STAThread]

--- a/DynamicWin/Main/RendererMain.cs
+++ b/DynamicWin/Main/RendererMain.cs
@@ -183,7 +183,7 @@ namespace DynamicWin.Main
             {
                 if (MenuManager.Instance.ActiveMenu is HomeMenu)
                 {
-                    MenuManager.OpenOverlayMenu(new VolumeAdjustMenu(), 100f);
+                    MenuManager.OpenOverlayMenu(new VolumeAdjustMenu(), 2.75f, Res.HomeMenu);
                 }
                 else if (VolumeAdjustMenu.timerUntilClose != null)
                 {
@@ -222,7 +222,7 @@ namespace DynamicWin.Main
                 initialScreenBrightness = BrightnessAdjustMenu.GetBrightness();
                 if (MenuManager.Instance.ActiveMenu is HomeMenu)
                 {
-                    MenuManager.OpenOverlayMenu(new BrightnessAdjustMenu(), 100f);
+                    MenuManager.OpenOverlayMenu(new BrightnessAdjustMenu(), 2.75f, Res.HomeMenu);
                 }
                 else if (BrightnessAdjustMenu.timerUntilClose != null)
                 {

--- a/DynamicWin/UI/Menu/Menus/BrightnessAdjustMenu.cs
+++ b/DynamicWin/UI/Menu/Menus/BrightnessAdjustMenu.cs
@@ -58,8 +58,6 @@ namespace DynamicWin.UI.Menu.Menus
         {
             base.Update();
 
-            if (timerUntilClose > 2.75f) MenuManager.CloseOverlay();
-
             islandScale = Mathf.Lerp(islandScale, 1f, 5f * RendererMain.Instance.DeltaTime);
 
             timerUntilClose += RendererMain.Instance.DeltaTime;

--- a/DynamicWin/UI/Menu/Menus/VolumeAdjustMenu.cs
+++ b/DynamicWin/UI/Menu/Menus/VolumeAdjustMenu.cs
@@ -100,8 +100,6 @@ namespace DynamicWin.UI.Menu.Menus
         {
             base.Update();
 
-            if (timerUntilClose > 2.75f) MenuManager.CloseOverlay();
-
             islandScale = Mathf.Lerp(islandScale, 1f, 5f * RendererMain.Instance.DeltaTime);
 
             var volume = GetVolumePercent();


### PR DESCRIPTION
# What's adjusted in v1.4.2b?
- Overlay menus like `VolumeAdjustMenu.cs` and `BrightnessAdjustMenu.cs` not using the new `OpenOverlayMenu()` overload implementation, causing for them to freeze and not return to the home menu.